### PR TITLE
Fix for #10925 — free TTY

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -58,10 +58,10 @@ function detect-clipboard() {
     function clipcopy() { cat "${1:-/dev/stdin}" > /dev/clipboard; }
     function clippaste() { cat /dev/clipboard; }
   elif [ -n "${WAYLAND_DISPLAY:-}" ] && (( ${+commands[wl-copy]} )) && (( ${+commands[wl-paste]} )); then
-    function clipcopy() { wl-copy < "${1:-/dev/stdin}"; }
+    function clipcopy() { cat "${1:-/dev/stdin}" | { wl-copy &>/dev/null &| }; }
     function clippaste() { wl-paste; }
   elif [ -n "${DISPLAY:-}" ] && (( ${+commands[xclip]} )); then
-    function clipcopy() { xclip -in -selection clipboard < "${1:-/dev/stdin}"; }
+    function clipcopy() { cat "${1:-/dev/stdin}" | { xclip -selection clipboard -in &>/dev/null &| }; }
     function clippaste() { xclip -out -selection clipboard; }
   elif [ -n "${DISPLAY:-}" ] && (( ${+commands[xsel]} )); then
     function clipcopy() { xsel --clipboard --input < "${1:-/dev/stdin}"; }


### PR DESCRIPTION
Fixing #10925. Launching `xclip` and `wl-copy` detached to avoid waiting for them to finish (and keeping terminal open) after quitting the shell.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Launchng `wl-copy` in the way to free TTY after copying.

## Other comments:

- Using separate `cat` and shell braces was the only option finally working for me, I will be glad to see the better way if any.
